### PR TITLE
Add alias for AllJobs

### DIFF
--- a/src/InteractsWithPayloadServiceProvider.php
+++ b/src/InteractsWithPayloadServiceProvider.php
@@ -18,6 +18,7 @@ class InteractsWithPayloadServiceProvider extends PackageServiceProvider
         $this->app->singleton('all-jobs', function () {
             return new AllJobs();
         });
+        $this->app->alias('all-jobs', AllJobs::class);
     }
 
     public function packageBooted()


### PR DESCRIPTION
Added alias since not everyone uses Facades and this prevents the creation of a new instance when injecting AllJobs class.